### PR TITLE
Fix !GetItem command crashing the game

### DIFF
--- a/src/apinterface.cpp
+++ b/src/apinterface.cpp
@@ -313,7 +313,8 @@ void ConnectAP()
       }
       nextCheckToGet = item.index + 1;
 
-      if (item.player == me) {
+      // Note: !GetItem has item.player == me but has location == -1 which crashes due to negative array indexing
+      if (item.player == me && item.location != -1) {
         auto localLocation = item.location - AP_OFFSET;
         if (!(*apStores[localLocation / 24])[localLocation % 24]) {
           printf("Not yet purchased on this save; storing\n");


### PR DESCRIPTION
`!GetItem` counts as a local item (as you get them via logging into text client as the meritous player) ie has `item.player == me` but has location `Cheat console` which has location id `-1`
Because the `!GetItem` item is local, the game tries to get the local location to see if it needs to mark off the caches. It does this by taking `593000` from the item's location (`-1`) to get `-593001` for its `localLocation` and then trying to access arrays with this negative number as the index crashes the game.

This crash repeats everytime the game reconnects to the server, as the server attempts to give the player the same item with location `-1`, rendering the game completely unable to be played.

Thankfully a simple fix is to ignore this special case.
I don't know if other special cases also exist though but if so, they may also need to be excluded in a similar way.

This was tested by running a build with and without the fix:
* The fixed build called !GetItem fine, and was able to also quit and reload with no issues.
* The current build broke as !GetItem was called. Also attempting to reload crashed immediately

