### PR TITLE
fix early cursed seal locking up the game

### DIFF
--- a/src/boss.c
+++ b/src/boss.c
@@ -472,12 +472,12 @@ void Curse()
   }
 
   // Every 25th monster becomes a curse. All other monsters are deleted
-
-  CurseEnemies();
-
-  // if the player picks up the cursed seal inside the starting room, start the boss fight immediately just incase they cannot get out
-  // this is the same code that triggers when we enter a boss room
-  if (player_room == 0) {
+  if (player_room != 0) {
+    CurseEnemies();
+  }
+  else {
+    // if the player picks up the cursed seal inside the starting room, start the boss fight immediately just incase they cannot get out
+    // this is the same code that triggers when we enter a boss room
     LockDoors(player_room);
     BossRoom(player_room);
   }

--- a/src/boss.c
+++ b/src/boss.c
@@ -474,6 +474,13 @@ void Curse()
   // Every 25th monster becomes a curse. All other monsters are deleted
 
   CurseEnemies();
+
+  // if the player picks up the cursed seal inside the starting room, start the boss fight immediately just incase they cannot get out
+  // this is the same code that triggers when we enter a boss room
+  if (player_room == 0) {
+    LockDoors(player_room);
+    BossRoom(player_room);
+  }
 }
 
 void DrawPowerObject()

--- a/src/demon.c
+++ b/src/demon.c
@@ -2570,7 +2570,9 @@ void CurseSingleEnemy(struct enemy *e)
 	static int NActiveRooms = 0;
 	int i;
 	int rm;
-	
+	int attempts;
+
+	// get the list of normal/post-special rooms that we can place cursed enemies in
 	if (NActiveRooms == 0) {
 		for (i = 0; i < rooms_to_gen; i++) {
 			if ((rooms[i].room_type == 0) || (rooms[i].room_type == 4)) {
@@ -2579,9 +2581,13 @@ void CurseSingleEnemy(struct enemy *e)
 		}
 	}
 
-	rm = ActiveRooms[rand()%NActiveRooms];
-	while ((rooms[rm].enemies > 3) || (rooms[rm].visited == 0)) {
-		rm = ActiveRooms[rand()%NActiveRooms];
+	attempts = 0;
+	rm = ActiveRooms[rand() % NActiveRooms];
+	// with the list we made earlier, find a low populated room we've visited to put a cursed enemy in
+	// limit the attempts because this may be impossible if cursed seal was picked up early or if no/few rooms were visited
+	while (((rooms[rm].enemies > 3) || (rooms[rm].visited == 0)) && attempts < 3000) {
+		rm = ActiveRooms[rand() % NActiveRooms];
+		attempts += 1;
 	}
 
 	e->x = rooms[rm].w * 16 + rooms[rm].x * 32;
@@ -2589,18 +2595,18 @@ void CurseSingleEnemy(struct enemy *e)
 	rooms[e->room].enemies--;
 	e->room = rm;
 	rooms[e->room].enemies++;
-	
+
 	e->image = enemy_sprites[9];
 	e->lives = 8;
 	e->str = 500;
 	e->speed = 1;
-	e->fire_rate = (rand()%4)+1;
+	e->fire_rate = (rand() % 4) + 1;
 	e->min_gems = 5000;
 	e->max_gems = 6000;
 	e->followdepth = 12;
 	e->creationcost = 6;
 	e->enemy_type = 10;
-	
+
 	ActivateSingleEnemy(e);
 }
 


### PR DESCRIPTION
Fixes #8 

When picking up cursed seal, the curse function does two things:
* Cull 4/5 of enemies 
* Curse 1/5 and place them in one of the visited rooms in the dungeon <-- this is where it locks up

When searching for a room to place a cursed enemy, the game does an infinite loop and only breaks out when it finds a suitable room, and if none exist then it never finishes. This only happens when cursed seal is picked up extremely early and is unlikely to happen under normal play (as you need 75% kills to pick it up generally).

This also opens up a future possibility of reducing the seal requirement.

Boss rooms only trigger on room transition usually, so using this without exploring any rooms is a softlock, I've also forced the boss room to be triggered if we are in the starting room when we call curse.

We can now face the boss instantly (would not recommend 💀)
![meritous-early-cursed-seal](https://github.com/user-attachments/assets/44d2880e-d9bd-49de-9316-5531bd26303a)
