### PR TITLE
fix deathlink

### DIFF
--- a/src/apinterface.cpp
+++ b/src/apinterface.cpp
@@ -257,8 +257,8 @@ void ConnectAP()
     ap_connect_sent = true; // TODO: move to APClient::State ?
   });
   ap->set_slot_connected_handler([](const json& data){
-    if (data.find("death_link") != data.end() && data["death_link"].is_boolean())
-      deathlink = data["death_link"].get<bool>();
+    if (data.find("death_link") != data.end() && data["death_link"].is_number_integer())
+      deathlink = data["death_link"].get<int>() == 1;
     else deathlink = false;
 
     if (data.find("goal") != data.end() && data["goal"].is_number_integer())

--- a/src/itemhandler.c
+++ b/src/itemhandler.c
@@ -370,7 +370,7 @@ void KillPlayer(const char *from) {
 
 void AnnounceDeath() {
   if (!isArchipelago() || !isDeathLink()) return;
-  if (SendDeathLink() && !deathlink_announced) PostMessage(74, 120, 0);
+  if (!deathlink_announced && SendDeathLink()) PostMessage(74, 120, 0);
   deathlink_announced = 0;
 }
 


### PR DESCRIPTION
Does two things:
* Fixes slot not correctly reading the deathlink setting, as it is an integer as opposed to a bool
* Fixes deathlinks triggering deathlinks

Currently meritous attempts to read the deathlink setting but is always false even when the yaml is set to true.

Secondly, the flag "deathlink_announced" is correctly set to true when we receive a deathlink, but we don't read it until after we resend the deathlink packet

Tested via creating a 2 slot meritous world both with deathlink:

![meritous-fixed-deathlink](https://github.com/user-attachments/assets/f732e0ac-d6aa-47f7-a754-28698d16cfd8)
